### PR TITLE
Set parameters as Optional in data sources, set username as Computed …

### DIFF
--- a/guacamole/data_guacamole_connection_kubernetes.go
+++ b/guacamole/data_guacamole_connection_kubernetes.go
@@ -91,7 +91,7 @@ func dataSourceConnectionKubernetes() *schema.Resource {
 			"parameters": {
 				Type:        schema.TypeList,
 				Description: "Guacamole connection parameters",
-				Required:    true,
+				Optional:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/guacamole/data_guacamole_connection_rdp.go
+++ b/guacamole/data_guacamole_connection_rdp.go
@@ -91,7 +91,7 @@ func dataSourceConnectionRDP() *schema.Resource {
 			"parameters": {
 				Type:        schema.TypeList,
 				Description: "Guacamole connection parameters",
-				Required:    true,
+				Optional:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/guacamole/data_guacamole_connection_vnc.go
+++ b/guacamole/data_guacamole_connection_vnc.go
@@ -91,7 +91,7 @@ func dataSourceConnectionVNC() *schema.Resource {
 			"parameters": {
 				Type:        schema.TypeList,
 				Description: "Guacamole connection parameters",
-				Required:    true,
+				Optional:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -109,7 +109,7 @@ func dataSourceConnectionVNC() *schema.Resource {
 						"username": {
 							Type:        schema.TypeString,
 							Description: "Username for vnc connection",
-							Required:    true,
+							Computed:    true,
 						},
 						"password": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
…in vnc data source

Some data sources required parameters {} block to be set, contrary to documentation.
VNC connection data source required also username to be set.

Changed to optional/computed. Please review.