### PR TITLE
avoid swallowing connection errors

### DIFF
--- a/guacamole/provider.go
+++ b/guacamole/provider.go
@@ -98,7 +98,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create guacamole client",
-			Detail:   "Unable to authenticate user for guacamole client",
+			Detail:   err.Error(),
 		})
 
 		return nil, diags


### PR DESCRIPTION
It took me quite a while to figure out why the provider wouldn't connect; and in the end it was a few different issues that also required printing the response body to debug.

This is a step in the right direction, though ideally eventually more information could be provided with the error.

Thanks so much for the provider!